### PR TITLE
MCPD-158 - Added support for a new Mura environment variable, muraInt…

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3911,14 +3911,14 @@ function attach(Mura){
 			if(Mura.mode.toLowerCase()=='rest'){
 				Mura.apiEndpoint=Mura.apiEndpoint.replace('/json/', '/rest/');
 			}
-			// Support for internal API environment variable to prefix API endpoint
-			if (typeof Mura.muraInternalApiEndpoint === 'string' &&
-					typeof Mura.apiEndpoint === 'string' &&
-					!Mura.apiEndpoint.startsWith(Mura.muraInternalApiEndpoint)) {
-						const prefix = Mura.muraInternalApiEndpoint.replace(/\/+$/, ''); // Remove trailing slashes
-						const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
-						Mura.apiEndpoint = `${prefix}/${endpoint}`;
-			}
+		}
+		// Support for internal API environment variable to prefix API endpoint
+		if (typeof Mura.muraInternalApiEndpoint === 'string' &&
+				typeof Mura.apiEndpoint === 'string' &&
+				!Mura.apiEndpoint.startsWith(Mura.muraInternalApiEndpoint)) {
+					const prefix = Mura.muraInternalApiEndpoint.replace(/\/+$/, ''); // Remove trailing slashes
+					const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
+					Mura.apiEndpoint = `${prefix}/${endpoint}`;
 		}
 		return Mura.apiEndpoint;
 	}

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3911,7 +3911,15 @@ function attach(Mura){
 			if(Mura.mode.toLowerCase()=='rest'){
 				Mura.apiEndpoint=Mura.apiEndpoint.replace('/json/', '/rest/');
 			}
-		} 
+			// Support for internal API environment variable to prefix API endpoint
+			if (typeof Mura.muraInternalApiEndpoint === 'string' &&
+					typeof Mura.apiEndpoint === 'string' &&
+					!Mura.apiEndpoint.startsWith(Mura.muraInternalApiEndpoint)) {
+						const prefix = Mura.muraInternalApiEndpoint.replace(/\/+$/, ''); // Remove trailing slashes
+						const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
+						Mura.apiEndpoint = `${prefix}/${endpoint}`;
+			}
+		}
 		return Mura.apiEndpoint;
 	}
 


### PR DESCRIPTION
…ernalApiEndpoint. This prepends the muraInternalApiEndpoint, if available, to the Mura api endpoint when getApiEndpoint is called.

Hi @bowler865 @eliasmadera-br , could you take a look at my update for the getApiEndpoint() function. I am adding support for a new Mura Environment variable called `muraInternalApiEndpoint` which gets prepended to the Mura.apiEndpoint when it gets returned if it is available.

Let me know if you see anything that seems off or if you can foresee an issue with the current logic.

If it does look go to you, let me know if this process for merging into the master branch looks good or if I need to follow a different process:

1. Create Feature branch from master and implement change
2. Make PR for feature branch to master
3. Once merged, checkout master update the package.json version to x.x.xxx-rc.1(or some variation) and run publish:@murasoftware/mura.js-rc
4. Test the RC version and if everything looks good, update the package.json version to the next minor version and remove the rc.1 label and run publish:@murasoftware/mura.js
5. Final step is copying the contents in the /dist folder in the mura-js repo and replacing the /app/core/modules/core_assets/ in the Mura repo.
