### PR TITLE
MCPD-158 - Add internalRootpath config to route server-side API calls through internal domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "buffer": "^6.0.3",
     "cross-env": "^7.0.3",
     "cross-fetch": "^3.1.5",
+    "encoding": "^0.1.13",
     "escape-html": "^1.0.3",
     "grunt-contrib-concat": "^2.1.0",
     "handlebars": "^4.7.7",

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3913,10 +3913,10 @@ function attach(Mura){
 			}
 		}
 		// Support for internal API environment variable to prefix API endpoint
-		if (typeof Mura.muraInternalApiEndpoint === 'string' &&
+		if (typeof Mura.internalApiDomain === 'string' &&
 				typeof Mura.apiEndpoint === 'string' &&
-				!Mura.apiEndpoint.startsWith(Mura.muraInternalApiEndpoint)) {
-					const prefix = Mura.muraInternalApiEndpoint.replace(/\/+$/, ''); // Remove trailing slashes
+				!Mura.apiEndpoint.startsWith(Mura.internalApiDomain)) {
+					const prefix = Mura.internalApiDomain.replace(/\/+$/, ''); // Remove trailing slashes
 					const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
 					Mura.apiEndpoint = `${prefix}/${endpoint}`;
 		}

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -4025,11 +4025,10 @@ function attach(Mura){
 			config.context = config.rootpath;
 		}
 
-		// MCPD-158: Support for `internalRootpath` environment variable to prefix API endpoint 
+		// MCPD-158: Support for `internalRootpath` environment variable to prefix API endpoint
 		// when running in node for server side rendering scenarios
 		if (config.internalRootpath && isInNode()) {
 			config.context = config.internalRootpath;
-			config.rootpath = config.internalRootpath;
 		}
 
 		if (config.endpoint) {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3912,32 +3912,12 @@ function attach(Mura){
 				Mura.apiEndpoint=Mura.apiEndpoint.replace('/json/', '/rest/');
 			}
 		}
-		
-		Mura.apiEndpoint = getInternalApiDomain(Mura.apiEndpoint);
 
 		return Mura.apiEndpoint;
 	}
 
 	function setAPIEndpoint(apiEndpoint){
 		Mura.apiEndpoint=apiEndpoint;
-	}
-
-	function getInternalApiDomain(apiEndpoint) {
-		// MCPD-158: Support for internal API environment variable to prefix API endpoint
-		if (
-			typeof Mura.internalApiDomain === "string" &&
-			Mura.internalApiDomain &&
-			typeof apiEndpoint === "string" &&
-			apiEndpoint &&
-			!apiEndpoint.startsWith(Mura.internalApiDomain)
-		) {
-			const endpointPath = apiEndpoint.replace(/^(https?:)?\/\/[^/]+/, ''); // Remove existing domain
-			const prefix = Mura.internalApiDomain.replace(/\/+$/, ''); // Remove trailing slashes
-			const endpoint = endpointPath.replace(/^\/+/, ''); // Remove leading slashes
-			return `${prefix}/${endpoint}`; // Return new api endpoint with internal domain
-		}
-
-		return apiEndpoint; // Return original if no changes needed
 	}
 
 	function setMode(mode){
@@ -4043,6 +4023,13 @@ function attach(Mura){
 
 		if (config.rootpath) {
 			config.context = config.rootpath;
+		}
+
+		// MCPD-158: Support for `internalRootpath` environment variable to prefix API endpoint 
+		// when running in node for server side rendering scenarios
+		if (config.internalRootpath && isInNode()) {
+			config.context = config.internalRootpath;
+			config.rootpath = config.internalRootpath;
 		}
 
 		if (config.endpoint) {
@@ -4495,7 +4482,6 @@ function attach(Mura){
 			getBreakpoint:getBreakpoint,
 			getAPIEndpoint:getAPIEndpoint,
 			setAPIEndpoint:setAPIEndpoint,
-			getInternalApiDomain: getInternalApiDomain,
 			getMode:getMode,
 			setMode:setMode,
 			getRenderMode: getRenderMode,

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -4495,6 +4495,7 @@ function attach(Mura){
 			getBreakpoint:getBreakpoint,
 			getAPIEndpoint:getAPIEndpoint,
 			setAPIEndpoint:setAPIEndpoint,
+			getInternalApiDomain: getInternalApiDomain,
 			getMode:getMode,
 			setMode:setMode,
 			getRenderMode: getRenderMode,

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3911,14 +3911,14 @@ function attach(Mura){
 			if(Mura.mode.toLowerCase()=='rest'){
 				Mura.apiEndpoint=Mura.apiEndpoint.replace('/json/', '/rest/');
 			}
-			// Support for internal API environment variable to prefix API endpoint
-			if (typeof Mura.muraInternalApiEndpoint === 'string' &&
-					typeof Mura.apiEndpoint === 'string' &&
-					!Mura.apiEndpoint.startsWith(Mura.muraInternalApiEndpoint)) {
-						const prefix = Mura.muraInternalApiEndpoint.replace(/\/+$/, ''); // Remove trailing slashes
-						const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
-						Mura.apiEndpoint = `${prefix}/${endpoint}`;
-			}
+		}
+		// Support for internal API environment variable to prefix API endpoint
+		if (typeof Mura.muraInternalApiEndpoint === 'string' &&
+				typeof Mura.apiEndpoint === 'string' &&
+				!Mura.apiEndpoint.startsWith(Mura.muraInternalApiEndpoint)) {
+					const prefix = Mura.muraInternalApiEndpoint.replace(/\/+$/, ''); // Remove trailing slashes
+					const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
+					Mura.apiEndpoint = `${prefix}/${endpoint}`;
 		}
 		return Mura.apiEndpoint;
 	}

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3912,19 +3912,32 @@ function attach(Mura){
 				Mura.apiEndpoint=Mura.apiEndpoint.replace('/json/', '/rest/');
 			}
 		}
-		// Support for internal API environment variable to prefix API endpoint
-		if (typeof Mura.internalApiDomain === 'string' &&
-				typeof Mura.apiEndpoint === 'string' &&
-				!Mura.apiEndpoint.startsWith(Mura.internalApiDomain)) {
-					const prefix = Mura.internalApiDomain.replace(/\/+$/, ''); // Remove trailing slashes
-					const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
-					Mura.apiEndpoint = `${prefix}/${endpoint}`;
-		}
+		
+		Mura.apiEndpoint = getInternalApiDomain(Mura.apiEndpoint);
+
 		return Mura.apiEndpoint;
 	}
 
 	function setAPIEndpoint(apiEndpoint){
 		Mura.apiEndpoint=apiEndpoint;
+	}
+
+	function getInternalApiDomain(apiEndpoint) {
+		// MCPD-158: Support for internal API environment variable to prefix API endpoint
+		if (
+			typeof Mura.internalApiDomain === "string" &&
+			Mura.internalApiDomain &&
+			typeof apiEndpoint === "string" &&
+			apiEndpoint &&
+			!apiEndpoint.startsWith(Mura.internalApiDomain)
+		) {
+			const endpointPath = apiEndpoint.replace(/^(https?:)?\/\/[^/]+/, ''); // Remove existing domain
+			const prefix = Mura.internalApiDomain.replace(/\/+$/, ''); // Remove trailing slashes
+			const endpoint = endpointPath.replace(/^\/+/, ''); // Remove leading slashes
+			return `${prefix}/${endpoint}`; // Return new api endpoint with internal domain
+		}
+
+		return apiEndpoint; // Return original if no changes needed
 	}
 
 	function setMode(mode){

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3911,7 +3911,15 @@ function attach(Mura){
 			if(Mura.mode.toLowerCase()=='rest'){
 				Mura.apiEndpoint=Mura.apiEndpoint.replace('/json/', '/rest/');
 			}
-		} 
+			// Support for internal API environment variable to prefix API endpoint
+			if (typeof Mura.muraInternalApiEndpoint === 'string' &&
+					typeof Mura.apiEndpoint === 'string' &&
+					!Mura.apiEndpoint.startsWith(Mura.muraInternalApiEndpoint)) {
+						const prefix = Mura.muraInternalApiEndpoint.replace(/\/+$/, ''); // Remove trailing slashes
+						const endpoint = Mura.apiEndpoint.replace(/^\/+/, ''); // Remove leading slashes
+						Mura.apiEndpoint = `${prefix}/${endpoint}`;
+			}
+		}
 		return Mura.apiEndpoint;
 	}
 

--- a/src/core/req-instance.js
+++ b/src/core/req-instance.js
@@ -152,7 +152,21 @@ function attach(Mura){
 							}
 						}
 					})
-				}	
+				}
+
+				// MCPD-158: When internalRootpath is set, API calls are routed through the internal network (e.g. Cloud Map)
+				// instead of the public domain. Mura relies on host headers to identify the site, 
+				// but in ISR/static contexts there is no incoming request to forward them from.
+				if (Mura.internalRootpath && !config.headers['host']) {
+					try {
+						const { hostname, protocol } = new URL(Mura.rootpath);
+						config.headers['host'] = hostname;
+						config.headers['x-forwarded-host'] = hostname;
+						config.headers['x-forwarded-proto'] = protocol.replace(':', '');
+					} catch(e) {
+						console.log('Error parsing Mura.rootpath for internalRootpath support', e);
+					}
+				}
 				
 				let h;
 	


### PR DESCRIPTION
Add new `MURA_INTERNAL_ROOTPATH` environment variable to support routing SSR API calls through an internal network (e.g., AWS Cloud Map), while preserving `MURA_ROOTPATH` for client-side API calls using the public domain.